### PR TITLE
Decrease Pan Sensitivity.

### DIFF
--- a/Sources/Menu-SwiftUI/MenuViewModel.swift
+++ b/Sources/Menu-SwiftUI/MenuViewModel.swift
@@ -55,6 +55,8 @@ final class MenuViewModel: ObservableObject {
     }
 
     func draggingChanged(with value: DragGesture.Value) {
+        guard abs(value.translation.width) >= abs(value.translation.height) else { return }
+        
         updateStateForDraggingChanged(given: value.translation.width)
 
         withAnimation {


### PR DESCRIPTION
Decreased the Pan sensitivity so that if the drag is more vertical than horizontal,
the drawer does not start to open as such an action indicates vertical scrolling.